### PR TITLE
Support offset canvas

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -109,8 +109,9 @@ export const Canvas = React.memo(({ children, props, style, ...rest }) => {
   }, [ready, size, camera])
 
   const intersect = useCallback((event, fn) => {
-    const x = (event.clientX / state.current.size.width) * 2 - 1
-    const y = -(event.clientY / state.current.size.height) * 2 + 1
+    const canvasRect = canvas.current.getBoundingClientRect()
+    const x = ((event.clientX - canvasRect.left) / (canvasRect.right - canvasRect.left)) * 2 - 1
+    const y = -((event.clientY - canvasRect.top) / (canvasRect.bottom - canvasRect.top)) * 2 + 1
     mouse.set(x, y, 0.5)
     raycaster.setFromCamera(mouse, state.current.camera)
     // TODO only inspect onbjects that have handlers


### PR DESCRIPTION
The `intersect` calculation only worked if the canvas was at 0,0 in the viewport. This should adjust it so that it takes into account the canvas position and size.