### PR TITLE
Fix late ref for useMeasure

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -12,7 +12,7 @@ function useMeasure() {
   useEffect(() => {
     if (ref.current) ro.observe(ref.current)
     return () => ro.disconnect()
-  }, [])
+  }, [ref.current])
   return [{ ref }, bounds]
 }
 


### PR DESCRIPTION
If the ref is only bound later the ResizeObserver won't be set up.