### PR TITLE
useThree: Remove unused argument placeholder

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -16,7 +16,7 @@ export function useRender(fn, takeOverRenderloop) {
   }, [])
 }
 
-export function useThree(fn) {
+export function useThree() {
   const { subscribe, ...props } = useContext(stateContext)
   return props
 }


### PR DESCRIPTION
Thanks for this library!

I was playing around with some type definitions for #11, and noticed this argument wasn't used.