### PR TITLE
`useLayoutEffect` in render loop

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
-import { useRef, useEffect, useState, useCallback } from 'react'
+import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 import { invalidate, applyProps, render, renderGl, unmountComponentAtNode } from './reconciler'
 
@@ -241,7 +241,7 @@ export const Canvas = React.memo(
     }, [])
 
     // Render v-dom into scene
-    useEffect(() => {
+    useLayoutEffect(() => {
       if (size.width > 0 && size.height > 0) {
         render(
           <stateContext.Provider value={sharedState.current}>


### PR DESCRIPTION
Currently main render loop is being run inside `useEffect`, which causes a noticeable 1 frame lag when compared to other animations, like cursor movement.
Switching to `useLayoutEffect` eliminates said lag.