### PR TITLE
Change the generation of the typings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
-import { Canvas } from './src/canvas.tsx'
-import { useRender, useThree, useUpdate, useResource } from './src/hooks.tsx'
+import { Canvas } from './src/canvas'
+import { useRender, useThree, useUpdate, useResource } from './src/hooks'
 import {
   addEffect,
   invalidate,
@@ -8,9 +8,9 @@ import {
   extend,
   applyProps,
   createPortal,
-} from './src/reconciler.tsx'
+} from './src/reconciler'
 
-const apply = args => {
+const apply = (args: any) => {
   console.warn('react-three-fiber: Please use extend ✅ instead of apply ❌, the former will be made obsolete soon!')
   extend(args)
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,4 +48,4 @@ function createConfig(entry, out) {
   ]
 }
 
-export default [...createConfig('index', 'index')]
+export default [...createConfig('index.ts', 'index')]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,9 @@
     "declaration": true,
     "removeComments": true,
     "emitDeclarationOnly": true,
-    "outFile": "types/index.d.ts"
+    "outDir": "types",
+    "resolveJsonModule": true
   },
-  "include": ["./src/**/*"],
+  "include": ["./index.ts", "/src/**/*"],
   "exclude": ["./node_modules/**/*"]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,127 +1,27 @@
-/// <reference types="react" />
-declare module 'reconciler' {
-  export function addEffect(callback: Function): void
-  export function renderGl(state: any, timestamp: number, repeat?: number, runGlobalEffects?: boolean): number
-  export function invalidate(state: any, frames?: number): void
-  export const extend: (objects: any) => any
-  export function applyProps(instance: any, newProps: any, oldProps?: any, accumulative?: boolean): void
-  export function render(element: any, container: any, state: any): any
-  export function unmountComponentAtNode(container: any): void
-  export function createPortal(
-    children: any,
-    containerInfo: any,
-    implementation: any,
-    key?: null
-  ): {
-    $$typeof: number | symbol
-    key: string | null
-    children: any
-    containerInfo: any
-    implementation: any
-  }
-}
-declare module 'canvas' {
-  import * as THREE from 'three'
-  import * as React from 'react'
-  export type CanvasContext = {
-    ready: boolean
-    manual: boolean
-    vr: boolean
-    active: boolean
-    invalidateFrameloop: boolean
-    updateDefaultCamera: boolean
-    frames: number
-    aspect: number
-    subscribers: Function[]
-    subscribe: (callback: Function) => () => any
-    setManual: (takeOverRenderloop: boolean) => any
-    setDefaultCamera: (camera: THREE.Camera) => any
-    invalidate: () => any
-    gl?: THREE.WebGLRenderer
-    camera: THREE.Camera
-    raycaster: THREE.Raycaster
-    mouse: THREE.Vector2
-    scene: THREE.Scene
-    captured?: THREE.Intersection
-    canvas?: HTMLCanvasElement
-    canvasRect?: ClientRect | DOMRect
-    size?: {
-      left: number
-      top: number
-      width: number
-      height: number
-    }
-    viewport?: {
-      width: number
-      height: number
-      factor: number
-    }
-  }
-  export type CanvasProps = {
-    children?: React.ReactNode
-    vr?: boolean
-    orthographic?: boolean
-    invalidateFrameloop?: boolean
-    updateDefaultCamera?: boolean
-    gl?: object
-    camera?: object
-    raycaster?: object
-    style?: React.CSSProperties
-    pixelRatio?: number
-    onCreated?: Function
-  }
-  export type Measure = [
-    {
-      ref: React.MutableRefObject<HTMLDivElement | undefined>
-    },
-    {
-      left: number
-      top: number
-      width: number
-      height: number
-    }
-  ]
-  export type IntersectObject = Event &
-    THREE.Intersection & {
-      ray: THREE.Raycaster
-      stopped: {
-        current: boolean
-      }
-      uuid: string
-    }
-  export const stateContext: React.Context<CanvasContext>
-  export const Canvas: React.MemoExoticComponent<
-    ({
-      children,
-      gl,
-      camera,
-      orthographic,
-      raycaster,
-      style,
-      pixelRatio,
-      vr,
-      invalidateFrameloop,
-      updateDefaultCamera,
-      onCreated,
-      ...rest
-    }: CanvasProps) => JSX.Element
-  >
-}
-declare module 'hooks' {
-  import { CanvasContext } from 'canvas'
-  type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-  export function useRender(fn: Function, takeOverRenderloop?: boolean, deps?: []): void
-  export function useThree(): Omit<CanvasContext, 'subscribe'>
-  export function useUpdate(
-    callback: Function,
-    dependents: [],
-    optionalRef?: React.MutableRefObject<any>
-  ): React.MutableRefObject<any>
-  export function useResource(optionalRef?: React.MutableRefObject<any>): any
-}
-
- declare module 'react-three-fiber' {
-    export * from 'reconciler';
-    export * from 'canvas';
-    export * from 'hooks';
+import { Canvas } from './src/canvas'
+import { useRender, useThree, useUpdate, useResource } from './src/hooks'
+import {
+  addEffect,
+  invalidate,
+  render,
+  unmountComponentAtNode,
+  extend,
+  applyProps,
+  createPortal,
+} from './src/reconciler'
+declare const apply: (args: any) => void
+export {
+  Canvas,
+  addEffect,
+  invalidate,
+  render,
+  createPortal,
+  unmountComponentAtNode,
+  apply,
+  extend,
+  applyProps,
+  useRender,
+  useThree,
+  useUpdate,
+  useResource,
 }

--- a/types/src/canvas.d.ts
+++ b/types/src/canvas.d.ts
@@ -1,0 +1,85 @@
+import * as THREE from 'three'
+import * as React from 'react'
+export declare type CanvasContext = {
+  ready: boolean
+  manual: boolean
+  vr: boolean
+  active: boolean
+  invalidateFrameloop: boolean
+  updateDefaultCamera: boolean
+  frames: number
+  aspect: number
+  subscribers: Function[]
+  subscribe: (callback: Function) => () => any
+  setManual: (takeOverRenderloop: boolean) => any
+  setDefaultCamera: (camera: THREE.Camera) => any
+  invalidate: () => any
+  gl?: THREE.WebGLRenderer
+  camera: THREE.Camera
+  raycaster: THREE.Raycaster
+  mouse: THREE.Vector2
+  scene: THREE.Scene
+  captured?: THREE.Intersection
+  canvas?: HTMLCanvasElement
+  canvasRect?: ClientRect | DOMRect
+  size?: {
+    left: number
+    top: number
+    width: number
+    height: number
+  }
+  viewport?: {
+    width: number
+    height: number
+    factor: number
+  }
+}
+export declare type CanvasProps = {
+  children?: React.ReactNode
+  vr?: boolean
+  orthographic?: boolean
+  invalidateFrameloop?: boolean
+  updateDefaultCamera?: boolean
+  gl?: object
+  camera?: object
+  raycaster?: object
+  style?: React.CSSProperties
+  pixelRatio?: number
+  onCreated?: Function
+}
+export declare type Measure = [
+  {
+    ref: React.MutableRefObject<HTMLDivElement | undefined>
+  },
+  {
+    left: number
+    top: number
+    width: number
+    height: number
+  }
+]
+export declare type IntersectObject = Event &
+  THREE.Intersection & {
+    ray: THREE.Raycaster
+    stopped: {
+      current: boolean
+    }
+    uuid: string
+  }
+export declare const stateContext: React.Context<CanvasContext>
+export declare const Canvas: React.MemoExoticComponent<
+  ({
+    children,
+    gl,
+    camera,
+    orthographic,
+    raycaster,
+    style,
+    pixelRatio,
+    vr,
+    invalidateFrameloop,
+    updateDefaultCamera,
+    onCreated,
+    ...rest
+  }: CanvasProps) => JSX.Element
+>

--- a/types/src/hooks.d.ts
+++ b/types/src/hooks.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="react" />
+import { CanvasContext } from './canvas'
+declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+export declare function useRender(fn: Function, takeOverRenderloop?: boolean, deps?: any[]): void
+export declare function useThree(): Omit<CanvasContext, 'subscribe'>
+export declare function useUpdate(
+  callback: Function,
+  dependents: any[],
+  optionalRef?: React.MutableRefObject<any>
+): React.MutableRefObject<any>
+export declare function useResource(optionalRef?: React.MutableRefObject<any>): any
+export {}

--- a/types/src/reconciler.d.ts
+++ b/types/src/reconciler.d.ts
@@ -1,0 +1,19 @@
+export declare function addEffect(callback: Function): void
+export declare function renderGl(state: any, timestamp: number, repeat?: number, runGlobalEffects?: boolean): number
+export declare function invalidate(state: any, frames?: number): void
+export declare const extend: (objects: any) => any
+export declare function applyProps(instance: any, newProps: any, oldProps?: any, accumulative?: boolean): void
+export declare function render(element: any, container: any, state: any): any
+export declare function unmountComponentAtNode(container: any): void
+export declare function createPortal(
+  children: any,
+  containerInfo: any,
+  implementation: any,
+  key?: null
+): {
+  $$typeof: number | symbol
+  key: string | null
+  children: any
+  containerInfo: any
+  implementation: any
+}


### PR DESCRIPTION
A followup to #104, I converted index.ts into a TypeScript file as the generated typings lacked an entry point, and also changed the export mode for the typings to use a directory instead of a single file (necessary for the type definitions to be properly defined).