### PR TITLE
clear subscribers when new canvas is created

### DIFF
--- a/examples/components/MultiRenderer.js
+++ b/examples/components/MultiRenderer.js
@@ -1,0 +1,57 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { Canvas, useRender } from 'react-three-fiber'
+
+const CanvasStyle = {
+  width: '100vw',
+  height: '50vh',
+}
+
+const Obj = () => {
+  const meshRef = useRef()
+  useRender(() => {
+    if (meshRef.current) {
+      meshRef.current.rotation.y += 0.03
+    }
+  })
+  return (
+    <mesh ref={meshRef}>
+      <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
+      <meshNormalMaterial attach="material" />
+    </mesh>
+  )
+}
+const SpinningScene = () => (
+  <div style={CanvasStyle}>
+    <Canvas>
+      <Obj />
+    </Canvas>
+  </div>
+)
+
+const StaticScene = () => (
+  <div style={CanvasStyle}>
+    <Canvas>
+      <mesh>
+        <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
+        <meshNormalMaterial attach="material" />
+      </mesh>
+    </Canvas>
+  </div>
+)
+/** Main component */
+function App() {
+  const [secondScene, setSecondScene] = useState(false)
+
+  useEffect(() => {
+    setTimeout(() => setSecondScene(true), 5000)
+  }, [])
+
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <SpinningScene />
+      {secondScene && <StaticScene />}
+    </div>
+  )
+}
+
+export default App

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -135,6 +135,7 @@ export const Canvas = React.memo(
     // Public state
     const state = useRef({
       ...defaultRef,
+      subscribers: [],
       subscribe: (fn: Function) => {
         state.current.subscribers.push(fn)
         return () => (state.current.subscribers = state.current.subscribers.filter(s => s !== fn))


### PR DESCRIPTION
As mentioned in https://github.com/drcmda/react-three-fiber/issues/125, spreading `defaultRef` into the canvas state causes all instances of `Canvas` to share a reference to one subscribers array when they should each have their own subscribers array.

Also added an example file when I was testing, happy to remove if that's not necessary.