### PR TITLE
properly `event.stopPropagation()` to allow outer DOM to pick up that signal

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -312,10 +312,8 @@ export const Canvas = React.memo(
             unprojectedPoint,
             ray: defaultRaycaster.ray,
             // Hijack stopPropagation, which just sets a flag
-            stopPropagation() {
-              event.stopPropagation()
-              stopped.current = true
-            },
+            stopPropagation: () => ((stopped.current = true), event.stopPropagation()),
+            preventDefault: () => event.preventDefault(),
           })
 
           if (stopped.current === true) break

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -312,7 +312,10 @@ export const Canvas = React.memo(
             unprojectedPoint,
             ray: defaultRaycaster.ray,
             // Hijack stopPropagation, which just sets a flag
-            stopPropagation: () => (stopped.current = true),
+            stopPropagation() {
+              event.stopPropagation()
+              stopped.current = true
+            },
           })
 
           if (stopped.current === true) break


### PR DESCRIPTION
Right now, there's no easy way to stop propagation of events "handled" by 3d objects. This should fix that issue.