### PR TITLE
Revert #135, expose `sourceEvent` instead

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -306,14 +306,14 @@ export const Canvas = React.memo(
           let stopped = { current: false }
 
           fn({
-            ...Object.assign({}, event),
+            ...event,
             ...hit,
             stopped,
             unprojectedPoint,
             ray: defaultRaycaster.ray,
             // Hijack stopPropagation, which just sets a flag
-            stopPropagation: () => ((stopped.current = true), event.stopPropagation()),
-            preventDefault: () => event.preventDefault(),
+            stopPropagation: () => (stopped.current = true),
+            sourceEvent: event,
           })
 
           if (stopped.current === true) break


### PR DESCRIPTION
Stopping "3D" propagation doesn't have to mean that you want to stop "source event" propagation. Exposing source event gives you fine-grain control over what you really want to do.