### PR TITLE
useLayoutEffect when setting state

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -159,7 +159,7 @@ export const Canvas = React.memo(
     const sharedState = useRef(state.current)
 
     // Writes locals into public state for distribution among subscribers, context, etc
-    useEffect(() => {
+    useLayoutEffect(() => {
       state.current.ready = ready
       state.current.size = size
       state.current.camera = defaultCam
@@ -196,7 +196,7 @@ export const Canvas = React.memo(
     }, [])
 
     // Adjusts default camera
-    useEffect(() => {
+    useLayoutEffect(() => {
       state.current.aspect = size.width / size.height || 0
 
       if ((state.current.camera as THREE.OrthographicCamera).isOrthographicCamera) {


### PR DESCRIPTION
Fix for #134 

The render runs with `useLayoutEffect`, that is being triggered before setting `size` and the `sharedState`, now they are synced