### PR TITLE
Fix crash when changing a primitive object

### DIFF
--- a/src/reconciler.tsx
+++ b/src/reconciler.tsx
@@ -116,7 +116,10 @@ export function applyProps(instance: any, newProps: any, oldProps: any = {}, acc
         }
         // Special treatment for objects with support for set/copy
         if (target && target.set && target.copy) {
-          if (target.constructor.name === value.constructor.name) target.copy(value)
+          if (value && value.constructor) {
+            if (target.constructor.name === value.constructor.name) target.copy(value)
+          }
+          
           else if (Array.isArray(value)) target.set(...value)
           else target.set(value)
           // Else, just overwrite the value


### PR DESCRIPTION
When changing a color deep inside and .obj object my application crashes

```
index.js:169 Uncaught TypeError: Cannot read property 'constructor' of undefined
    at index.js:169
    at Array.forEach (<anonymous>)
    at applyProps (index.js:145)
    at commitUpdate (index.js:360)
    at commitWork (react-reconciler.development.js:10454)
    at commitAllHostEffects (react-reconciler.development.js:11251)
    at HTMLUnknownElement.callCallback (react-reconciler.development.js:2311)
    at Object.invokeGuardedCallbackDev (react-reconciler.development.js:2360)
    at invokeGuardedCallback (react-reconciler.development.js:2411)
    at commitRoot (react-reconciler.development.js:11496)
    at react-reconciler.development.js:13082
    at Object.unstable_runWithPriority (scheduler.development.js:255)
    at completeRoot (react-reconciler.development.js:13081)
    at performWorkOnRoot (react-reconciler.development.js:13004)
    at performWork (react-reconciler.development.js:12909)
    at performSyncWork (react-reconciler.development.js:12883)
    at requestWork (react-reconciler.development.js:12738)
    at scheduleWork (react-reconciler.development.js:12551)
    at dispatchAction (react-reconciler.development.js:5759)
    at Subscription.checkForUpdates [as onStateChange] (useSelector.js:106)
    at Subscription.handleChangeWrapper (Subscription.js:70)
    at Subscription.js:25
    at batchedUpdates$1 (react-dom.development.js:21465)
    at Object.notify (Subscription.js:23)
    at Subscription.notifyNestedSubs (Subscription.js:65)
    at Provider.notifySubscribers (Provider.js:59)
    at Provider.notifySubscribers (react-hot-loader.development.js:720)
    at Subscription.handleChangeWrapper (Subscription.js:70)
    at dispatch (redux.js:221)
    at redux-saga-core.esm.js:1421
    at Object.toggleHouseColor (redux.js:476)
    at BlockPillar._onClick (BlockPillar.js:12)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:198)
    at invokeGuardedCallback (react-dom.development.js:252)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:267)
    at executeDispatch (react-dom.development.js:573)
    at executeDispatchesInOrder (react-dom.development.js:598)
    at executeDispatchesAndRelease (react-dom.development.js:697)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js:706)
    at forEachAccumulated (react-dom.development.js:678)
    at runEventsInBatch (react-dom.development.js:846)
    at runExtractedEventsInBatch (react-dom.development.js:854)
    at handleTopLevel (react-dom.development.js:5031)
    at batchedUpdates$1 (react-dom.development.js:21465)
    at batchedUpdates (react-dom.development.js:2249)
    at dispatchEvent (react-dom.development.js:5111)
    at react-dom.development.js:21522
    at Object.unstable_runWithPriority (scheduler.development.js:255)
    at interactiveUpdates$1 (react-dom.development.js:21521)
    at interactiveUpdates (react-dom.development.js:2270)
    at dispatchInteractiveEvent (react-dom.development.js:5087)
```

```
const [result, error, state] = usePromise(
    () => Promise.all([objectResource(objectPath), textureResource(colorPath)]),
    [objectPath, colorPath]
  )
```

```
const cachedObjectWithTexture = useMemo(
    () =>
      state === 'resolved' &&
      enhanceObjectWithTexture(result[0], result[1], {
        metalness,
        roughness,
        isTransparent,
      }),
    [result, state]
  )

  if (!result || !cachedObjectWithTexture || state !== 'resolved') {
    return null
  }

  return (
    <mesh visible position={position} rotation={rotation}>
      <primitive attach="geometry" object={cachedObjectWithTexture} />
    </mesh>
  )
```