### PR TITLE
Typescript refactoring / constructor parameters

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+export * from './src/three-types'
 export * from './src/canvas'
 import { useRender, useThree, useUpdate, useResource } from './src/hooks'
 import {

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -3,11 +3,8 @@ import { PointerEvent } from './canvas'
 
 export type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
 export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
-export type ClassParams<T> = Parameters<Extract<T, (...args: any[]) => any>>
-export interface ClassSignature<T> {
-  new <K extends keyof T>(...args: ClassParams<T[K]>): T
-}
-type Args<T> = ConstructorParameters<ClassSignature<T>>
+// @ts-ignore
+type Args<P> = P extends { prototype: any } ? Exclude<ConstructorParameters<P>, 'prototype'> : P
 
 export namespace ReactThreeFiber {
   type Euler = THREE.Euler | number[]
@@ -24,7 +21,7 @@ export namespace ReactThreeFiber {
     onWheel?: (e: PointerEvent) => void
   }
 
-  export type Node<T, P = Args<T>> = Overwrite<
+  export type Node<T, P> = Overwrite<
     Partial<T>,
     {
       /** Attaches this class onto the parent under the given name and nulls it on unmount */
@@ -34,7 +31,7 @@ export namespace ReactThreeFiber {
       /** Adds this class to an object on the parent under the given name and deletes it on unmount */
       attachObject?: [string, string]
       /** Constructor arguments */
-      args?: P
+      args?: Args<P>
       children?: React.ReactNode
       ref?: React.Ref<React.ReactNode>
       key?: React.Key
@@ -42,27 +39,26 @@ export namespace ReactThreeFiber {
     }
   >
 
-  export type Object3DNode<T> = Overwrite<
-    Node<T>,
+  export type Object3DNode<T, P> = Overwrite<
+    Node<T, P>,
     {
       position?: Vector3
       up?: Vector3
       scale?: Vector3
       rotation?: Euler
       matrix?: Matrix4
-      onUpdate?: (self: T) => void
     }
   > &
     ReactThreeFiber.Events
 
-  export type GeometryNode<T> = Overwrite<
-    Node<T>,
+  export type GeometryNode<T, P> = Overwrite<
+    Node<T, P>,
     {
       vertices?: Vector3[]
     }
   >
 
-  export type MaterialNode<T, P = Args<T>> = Overwrite<
+  export type MaterialNode<T, P> = Overwrite<
     Node<T, P>,
     {
       color?: Color
@@ -74,58 +70,64 @@ declare global {
   namespace JSX {
     interface IntrinsicElements {
       // @ts-ignore
-      audio: ReactThreeFiber.Object3DNode<THREE.Audio>
-      audioListener: ReactThreeFiber.Object3DNode<THREE.AudioListener>
-      positionalAudio: ReactThreeFiber.Object3DNode<THREE.PositionalAudio>
+      audio: ReactThreeFiber.Object3DNode<THREE.Audio, typeof THREE.Audio>
+      audioListener: ReactThreeFiber.Object3DNode<THREE.AudioListener, typeof THREE.AudioListener>
+      positionalAudio: ReactThreeFiber.Object3DNode<THREE.PositionalAudio, typeof THREE.PositionalAudio>
 
-      mesh: ReactThreeFiber.Object3DNode<THREE.Mesh>
-      scene: ReactThreeFiber.Object3DNode<THREE.Scene>
-      sprite: ReactThreeFiber.Object3DNode<THREE.Sprite>
-      lOD: ReactThreeFiber.Object3DNode<THREE.LOD>
-      skinnedMesh: ReactThreeFiber.Object3DNode<THREE.SkinnedMesh>
-      skeleton: ReactThreeFiber.Object3DNode<THREE.Skeleton>
-      bone: ReactThreeFiber.Object3DNode<THREE.Bone>
-      lineSegments: ReactThreeFiber.Object3DNode<THREE.LineSegments>
-      lineLoop: ReactThreeFiber.Object3DNode<THREE.LineLoop>
+      mesh: ReactThreeFiber.Object3DNode<THREE.Mesh, typeof THREE.Mesh>
+      scene: ReactThreeFiber.Object3DNode<THREE.Scene, typeof THREE.Scene>
+      sprite: ReactThreeFiber.Object3DNode<THREE.Sprite, typeof THREE.Sprite>
+      lOD: ReactThreeFiber.Object3DNode<THREE.LOD, typeof THREE.LOD>
+      skinnedMesh: ReactThreeFiber.Object3DNode<THREE.SkinnedMesh, typeof THREE.SkinnedMesh>
+      skeleton: ReactThreeFiber.Object3DNode<THREE.Skeleton, typeof THREE.Skeleton>
+      bone: ReactThreeFiber.Object3DNode<THREE.Bone, typeof THREE.Bone>
+      lineSegments: ReactThreeFiber.Object3DNode<THREE.LineSegments, typeof THREE.LineSegments>
+      lineLoop: ReactThreeFiber.Object3DNode<THREE.LineLoop, typeof THREE.LineLoop>
       // @ts-ignore
-      line: ReactThreeFiber.Object3DNode<THREE.Line>
-      points: ReactThreeFiber.Object3DNode<THREE.Points>
-      group: ReactThreeFiber.Object3DNode<THREE.Group>
-      immediateRenderObject: ReactThreeFiber.Object3DNode<THREE.ImmediateRenderObject>
+      line: ReactThreeFiber.Object3DNode<THREE.Line, typeof THREE.Line>
+      points: ReactThreeFiber.Object3DNode<THREE.Points, typeof THREE.Points>
+      group: ReactThreeFiber.Object3DNode<THREE.Group, typeof THREE.Group>
+      immediateRenderObject: ReactThreeFiber.Object3DNode<
+        THREE.ImmediateRenderObject,
+        typeof THREE.ImmediateRenderObject
+      >
 
       // cameras
-      camera: ReactThreeFiber.Object3DNode<THREE.Camera>
-      perspectiveCamera: ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera>
-      orthographicCamera: ReactThreeFiber.Object3DNode<THREE.OrthographicCamera>
-      cubeCamera: ReactThreeFiber.Object3DNode<THREE.CubeCamera>
-      arrayCamera: ReactThreeFiber.Object3DNode<THREE.ArrayCamera>
+      camera: ReactThreeFiber.Object3DNode<THREE.Camera, typeof THREE.Camera>
+      perspectiveCamera: ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera, typeof THREE.PerspectiveCamera>
+      orthographicCamera: ReactThreeFiber.Object3DNode<THREE.OrthographicCamera, typeof THREE.OrthographicCamera>
+      cubeCamera: ReactThreeFiber.Object3DNode<THREE.CubeCamera, typeof THREE.CubeCamera>
+      arrayCamera: ReactThreeFiber.Object3DNode<THREE.ArrayCamera, typeof THREE.ArrayCamera>
 
       // geometry
-      geometry: ReactThreeFiber.GeometryNode<THREE.Geometry>
-      instancedBufferGeometry: ReactThreeFiber.GeometryNode<THREE.InstancedBufferGeometry>
-      bufferGeometry: ReactThreeFiber.GeometryNode<THREE.BufferGeometry>
-      wireframeGeometry: ReactThreeFiber.GeometryNode<THREE.WireframeGeometry>
-      parametricGeometry: ReactThreeFiber.GeometryNode<THREE.ParametricGeometry>
-      tetrahedronGeometry: ReactThreeFiber.GeometryNode<THREE.TetrahedronGeometry>
-      octahedronGeometry: ReactThreeFiber.GeometryNode<THREE.OctahedronGeometry>
-      icosahedronGeometry: ReactThreeFiber.GeometryNode<THREE.IcosahedronGeometry>
-      dodecahedronGeometry: ReactThreeFiber.GeometryNode<THREE.DodecahedronGeometry>
-      polyhedronGeometry: ReactThreeFiber.GeometryNode<THREE.PolyhedronGeometry>
-      tubeGeometry: ReactThreeFiber.GeometryNode<THREE.TubeGeometry>
-      torusKnotGeometry: ReactThreeFiber.GeometryNode<THREE.TorusKnotGeometry>
-      torusGeometry: ReactThreeFiber.GeometryNode<THREE.TorusGeometry>
-      textGeometry: ReactThreeFiber.GeometryNode<THREE.TextGeometry>
-      sphereGeometry: ReactThreeFiber.GeometryNode<THREE.SphereGeometry>
-      ringGeometry: ReactThreeFiber.GeometryNode<THREE.RingGeometry>
-      planeGeometry: ReactThreeFiber.GeometryNode<THREE.PlaneGeometry>
-      latheGeometry: ReactThreeFiber.GeometryNode<THREE.LatheGeometry>
-      shapeGeometry: ReactThreeFiber.GeometryNode<THREE.ShapeGeometry>
-      extrudeGeometry: ReactThreeFiber.GeometryNode<THREE.ExtrudeGeometry>
-      edgesGeometry: ReactThreeFiber.GeometryNode<THREE.EdgesGeometry>
-      coneGeometry: ReactThreeFiber.GeometryNode<THREE.ConeGeometry>
-      cylinderGeometry: ReactThreeFiber.GeometryNode<THREE.CylinderGeometry>
-      circleGeometry: ReactThreeFiber.GeometryNode<THREE.CircleGeometry>
-      boxGeometry: ReactThreeFiber.GeometryNode<THREE.BoxGeometry>
+      geometry: ReactThreeFiber.GeometryNode<THREE.Geometry, typeof THREE.Geometry>
+      instancedBufferGeometry: ReactThreeFiber.GeometryNode<
+        THREE.InstancedBufferGeometry,
+        typeof THREE.InstancedBufferGeometry
+      >
+      bufferGeometry: ReactThreeFiber.GeometryNode<THREE.BufferGeometry, typeof THREE.BufferGeometry>
+      wireframeGeometry: ReactThreeFiber.GeometryNode<THREE.WireframeGeometry, typeof THREE.WireframeGeometry>
+      parametricGeometry: ReactThreeFiber.GeometryNode<THREE.ParametricGeometry, typeof THREE.ParametricGeometry>
+      tetrahedronGeometry: ReactThreeFiber.GeometryNode<THREE.TetrahedronGeometry, typeof THREE.TetrahedronGeometry>
+      octahedronGeometry: ReactThreeFiber.GeometryNode<THREE.OctahedronGeometry, typeof THREE.OctahedronGeometry>
+      icosahedronGeometry: ReactThreeFiber.GeometryNode<THREE.IcosahedronGeometry, typeof THREE.IcosahedronGeometry>
+      dodecahedronGeometry: ReactThreeFiber.GeometryNode<THREE.DodecahedronGeometry, typeof THREE.DodecahedronGeometry>
+      polyhedronGeometry: ReactThreeFiber.GeometryNode<THREE.PolyhedronGeometry, typeof THREE.PolyhedronGeometry>
+      tubeGeometry: ReactThreeFiber.GeometryNode<THREE.TubeGeometry, typeof THREE.TubeGeometry>
+      torusKnotGeometry: ReactThreeFiber.GeometryNode<THREE.TorusKnotGeometry, typeof THREE.TorusKnotGeometry>
+      torusGeometry: ReactThreeFiber.GeometryNode<THREE.TorusGeometry, typeof THREE.TorusGeometry>
+      textGeometry: ReactThreeFiber.GeometryNode<THREE.TextGeometry, typeof THREE.TextGeometry>
+      sphereGeometry: ReactThreeFiber.GeometryNode<THREE.SphereGeometry, typeof THREE.SphereGeometry>
+      ringGeometry: ReactThreeFiber.GeometryNode<THREE.RingGeometry, typeof THREE.RingGeometry>
+      planeGeometry: ReactThreeFiber.GeometryNode<THREE.PlaneGeometry, typeof THREE.PlaneGeometry>
+      latheGeometry: ReactThreeFiber.GeometryNode<THREE.LatheGeometry, typeof THREE.LatheGeometry>
+      shapeGeometry: ReactThreeFiber.GeometryNode<THREE.ShapeGeometry, typeof THREE.ShapeGeometry>
+      extrudeGeometry: ReactThreeFiber.GeometryNode<THREE.ExtrudeGeometry, typeof THREE.ExtrudeGeometry>
+      edgesGeometry: ReactThreeFiber.GeometryNode<THREE.EdgesGeometry, typeof THREE.EdgesGeometry>
+      coneGeometry: ReactThreeFiber.GeometryNode<THREE.ConeGeometry, typeof THREE.ConeGeometry>
+      cylinderGeometry: ReactThreeFiber.GeometryNode<THREE.CylinderGeometry, typeof THREE.CylinderGeometry>
+      circleGeometry: ReactThreeFiber.GeometryNode<THREE.CircleGeometry, typeof THREE.CircleGeometry>
+      boxGeometry: ReactThreeFiber.GeometryNode<THREE.BoxGeometry, typeof THREE.BoxGeometry>
 
       // materials
       material: ReactThreeFiber.MaterialNode<THREE.Material, [THREE.MaterialParameters]>
@@ -160,51 +162,63 @@ declare global {
       lineBasicMaterial: ReactThreeFiber.MaterialNode<THREE.LineBasicMaterial, [THREE.LineBasicMaterialParameters]>
 
       // lights and other
-      light: ReactThreeFiber.Object3DNode<THREE.Light>
-      spotLightShadow: ReactThreeFiber.Object3DNode<THREE.SpotLightShadow>
-      spotLight: ReactThreeFiber.Object3DNode<THREE.SpotLight>
-      pointLight: ReactThreeFiber.Object3DNode<THREE.PointLight>
-      rectAreaLight: ReactThreeFiber.Object3DNode<THREE.RectAreaLight>
-      hemisphereLight: ReactThreeFiber.Object3DNode<THREE.HemisphereLight>
-      directionalLightShadow: ReactThreeFiber.Object3DNode<THREE.DirectionalLightShadow>
-      directionalLight: ReactThreeFiber.Object3DNode<THREE.DirectionalLight>
-      ambientLight: ReactThreeFiber.Object3DNode<THREE.AmbientLight>
-      lightShadow: ReactThreeFiber.Object3DNode<THREE.LightShadow>
+      light: ReactThreeFiber.Object3DNode<THREE.Light, typeof THREE.Light>
+      spotLightShadow: ReactThreeFiber.Object3DNode<THREE.SpotLightShadow, typeof THREE.SpotLightShadow>
+      spotLight: ReactThreeFiber.Object3DNode<THREE.SpotLight, typeof THREE.SpotLight>
+      pointLight: ReactThreeFiber.Object3DNode<THREE.PointLight, typeof THREE.PointLight>
+      rectAreaLight: ReactThreeFiber.Object3DNode<THREE.RectAreaLight, typeof THREE.RectAreaLight>
+      hemisphereLight: ReactThreeFiber.Object3DNode<THREE.HemisphereLight, typeof THREE.HemisphereLight>
+      directionalLightShadow: ReactThreeFiber.Object3DNode<
+        THREE.DirectionalLightShadow,
+        typeof THREE.DirectionalLightShadow
+      >
+      directionalLight: ReactThreeFiber.Object3DNode<THREE.DirectionalLight, typeof THREE.DirectionalLight>
+      ambientLight: ReactThreeFiber.Object3DNode<THREE.AmbientLight, typeof THREE.AmbientLight>
+      lightShadow: ReactThreeFiber.Object3DNode<THREE.LightShadow, typeof THREE.LightShadow>
       // @ts-ignore
-      ambientLightProbe: ReactThreeFiber.Object3DNode<THREE.AmbientLightProbe>
+      ambientLightProbe: ReactThreeFiber.Object3DNode<THREE.AmbientLightProbe, typeof THREE.AmbientLightProbe>
       // @ts-ignore
-      hemisphereLightProbe: ReactThreeFiber.Object3DNode<THREE.HemisphereLightProbe>
+      hemisphereLightProbe: ReactThreeFiber.Object3DNode<THREE.HemisphereLightProbe, typeof THREE.HemisphereLightProbe>
       // @ts-ignore
-      lightProbe: ReactThreeFiber.Object3DNode<THREE.LightProbe>
+      lightProbe: ReactThreeFiber.Object3DNode<THREE.LightProbe, typeof THREE.LightProbe>
 
       // helpers
-      vertexNormalsHelper: ReactThreeFiber.Object3DNode<THREE.VertexNormalsHelper>
-      spotLightHelper: ReactThreeFiber.Object3DNode<THREE.SpotLightHelper>
-      skeletonHelper: ReactThreeFiber.Object3DNode<THREE.SkeletonHelper>
-      pointLightHelper: ReactThreeFiber.Object3DNode<THREE.PointLightHelper>
-      rectAreaLightHelper: ReactThreeFiber.Object3DNode<THREE.RectAreaLightHelper>
-      hemisphereLightHelper: ReactThreeFiber.Object3DNode<THREE.HemisphereLightHelper>
-      gridHelper: ReactThreeFiber.Object3DNode<THREE.GridHelper>
-      polarGridHelper: ReactThreeFiber.Object3DNode<THREE.PolarGridHelper>
-      positionalAudioHelper: ReactThreeFiber.Object3DNode<THREE.PositionalAudioHelper>
-      faceNormalsHelper: ReactThreeFiber.Object3DNode<THREE.FaceNormalsHelper>
-      directionalLightHelper: ReactThreeFiber.Object3DNode<THREE.DirectionalLightHelper>
-      cameraHelper: ReactThreeFiber.Object3DNode<THREE.CameraHelper>
-      boxHelper: ReactThreeFiber.Object3DNode<THREE.BoxHelper>
-      box3Helper: ReactThreeFiber.Object3DNode<THREE.Box3Helper>
-      planeHelper: ReactThreeFiber.Object3DNode<THREE.PlaneHelper>
-      arrowHelper: ReactThreeFiber.Object3DNode<THREE.ArrowHelper>
-      axesHelper: ReactThreeFiber.Object3DNode<THREE.AxesHelper>
+      vertexNormalsHelper: ReactThreeFiber.Object3DNode<THREE.VertexNormalsHelper, typeof THREE.VertexNormalsHelper>
+      spotLightHelper: ReactThreeFiber.Object3DNode<THREE.SpotLightHelper, typeof THREE.SpotLightHelper>
+      skeletonHelper: ReactThreeFiber.Object3DNode<THREE.SkeletonHelper, typeof THREE.SkeletonHelper>
+      pointLightHelper: ReactThreeFiber.Object3DNode<THREE.PointLightHelper, typeof THREE.PointLightHelper>
+      rectAreaLightHelper: ReactThreeFiber.Object3DNode<THREE.RectAreaLightHelper, typeof THREE.RectAreaLightHelper>
+      hemisphereLightHelper: ReactThreeFiber.Object3DNode<
+        THREE.HemisphereLightHelper,
+        typeof THREE.HemisphereLightHelper
+      >
+      gridHelper: ReactThreeFiber.Object3DNode<THREE.GridHelper, typeof THREE.GridHelper>
+      polarGridHelper: ReactThreeFiber.Object3DNode<THREE.PolarGridHelper, typeof THREE.PolarGridHelper>
+      positionalAudioHelper: ReactThreeFiber.Object3DNode<
+        THREE.PositionalAudioHelper,
+        typeof THREE.PositionalAudioHelper
+      >
+      faceNormalsHelper: ReactThreeFiber.Object3DNode<THREE.FaceNormalsHelper, typeof THREE.FaceNormalsHelper>
+      directionalLightHelper: ReactThreeFiber.Object3DNode<
+        THREE.DirectionalLightHelper,
+        typeof THREE.DirectionalLightHelper
+      >
+      cameraHelper: ReactThreeFiber.Object3DNode<THREE.CameraHelper, typeof THREE.CameraHelper>
+      boxHelper: ReactThreeFiber.Object3DNode<THREE.BoxHelper, typeof THREE.BoxHelper>
+      box3Helper: ReactThreeFiber.Object3DNode<THREE.Box3Helper, typeof THREE.Box3Helper>
+      planeHelper: ReactThreeFiber.Object3DNode<THREE.PlaneHelper, typeof THREE.PlaneHelper>
+      arrowHelper: ReactThreeFiber.Object3DNode<THREE.ArrowHelper, typeof THREE.ArrowHelper>
+      axesHelper: ReactThreeFiber.Object3DNode<THREE.AxesHelper, typeof THREE.AxesHelper>
 
       // textures
-      texture: ReactThreeFiber.Node<THREE.Texture>
-      videoTexture: ReactThreeFiber.Node<THREE.VideoTexture>
-      dataTexture: ReactThreeFiber.Node<THREE.DataTexture>
-      dataTexture3D: ReactThreeFiber.Node<THREE.DataTexture3D>
-      compressedTexture: ReactThreeFiber.Node<THREE.CompressedTexture>
-      cubeTexture: ReactThreeFiber.Node<THREE.CubeTexture>
-      canvasTexture: ReactThreeFiber.Node<THREE.CanvasTexture>
-      depthTexture: ReactThreeFiber.Node<THREE.DepthTexture>
+      texture: ReactThreeFiber.Node<THREE.Texture, typeof THREE.Texture>
+      videoTexture: ReactThreeFiber.Node<THREE.VideoTexture, typeof THREE.VideoTexture>
+      dataTexture: ReactThreeFiber.Node<THREE.DataTexture, typeof THREE.DataTexture>
+      dataTexture3D: ReactThreeFiber.Node<THREE.DataTexture3D, typeof THREE.DataTexture3D>
+      compressedTexture: ReactThreeFiber.Node<THREE.CompressedTexture, typeof THREE.CompressedTexture>
+      cubeTexture: ReactThreeFiber.Node<THREE.CubeTexture, typeof THREE.CubeTexture>
+      canvasTexture: ReactThreeFiber.Node<THREE.CanvasTexture, typeof THREE.CanvasTexture>
+      depthTexture: ReactThreeFiber.Node<THREE.DepthTexture, typeof THREE.DepthTexture>
     }
   }
 }

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -9,7 +9,7 @@ export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
  */
 type Args<T> = T extends (new (...args: any) => any) ? ConstructorParameters<T> : T
 
-export namespace ReactThreeFiber {
+export declare namespace ReactThreeFiber {
   type Euler = THREE.Euler | number[]
   type Matrix4 = THREE.Matrix4 | number[]
   type Vector3 = THREE.Vector3 | number[]

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -1,0 +1,210 @@
+import * as THREE from 'three'
+import { PointerEvent } from './canvas'
+
+export type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
+export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
+export type ClassParams<T> = Parameters<Extract<T, (...args: any[]) => any>>
+export interface ClassSignature<T> {
+  new <K extends keyof T>(...args: ClassParams<T[K]>): T
+}
+type Args<T> = ConstructorParameters<ClassSignature<T>>
+
+export namespace ReactThreeFiber {
+  type Euler = THREE.Euler | number[]
+  type Matrix4 = THREE.Matrix4 | number[]
+  type Vector3 = THREE.Vector3 | number[]
+  type Color = THREE.Color | number | string
+  export type Events = {
+    onClick?: (e: PointerEvent) => void
+    onPointerUp?: (e: PointerEvent) => void
+    onPointerDown?: (e: PointerEvent) => void
+    onPointerOver?: (e: PointerEvent) => void
+    onPointerOut?: (e: PointerEvent) => void
+    onPointerMove?: (e: PointerEvent) => void
+    onWheel?: (e: PointerEvent) => void
+  }
+
+  export type Node<T, P = Args<T>> = Overwrite<
+    Partial<T>,
+    {
+      /** Attaches this class onto the parent under the given name and nulls it on unmount */
+      attach?: string
+      /** Appends this class to an array on the parent under the given name and removes it on unmount */
+      attachArray?: string
+      /** Adds this class to an object on the parent under the given name and deletes it on unmount */
+      attachObject?: [string, string]
+      /** Constructor arguments */
+      args?: P
+      children?: React.ReactNode
+      ref?: React.Ref<React.ReactNode>
+      key?: React.Key
+      onUpdate?: (self: T) => void
+    }
+  >
+
+  export type Object3DNode<T> = Overwrite<
+    Node<T>,
+    {
+      position?: Vector3
+      up?: Vector3
+      scale?: Vector3
+      rotation?: Euler
+      matrix?: Matrix4
+      onUpdate?: (self: T) => void
+    }
+  > &
+    ReactThreeFiber.Events
+
+  export type GeometryNode<T> = Overwrite<
+    Node<T>,
+    {
+      vertices?: Vector3[]
+    }
+  >
+
+  export type MaterialNode<T, P = Args<T>> = Overwrite<
+    Node<T, P>,
+    {
+      color?: Color
+    }
+  >
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      // @ts-ignore
+      audio: ReactThreeFiber.Object3DNode<THREE.Audio>
+      audioListener: ReactThreeFiber.Object3DNode<THREE.AudioListener>
+      positionalAudio: ReactThreeFiber.Object3DNode<THREE.PositionalAudio>
+
+      mesh: ReactThreeFiber.Object3DNode<THREE.Mesh>
+      scene: ReactThreeFiber.Object3DNode<THREE.Scene>
+      sprite: ReactThreeFiber.Object3DNode<THREE.Sprite>
+      lOD: ReactThreeFiber.Object3DNode<THREE.LOD>
+      skinnedMesh: ReactThreeFiber.Object3DNode<THREE.SkinnedMesh>
+      skeleton: ReactThreeFiber.Object3DNode<THREE.Skeleton>
+      bone: ReactThreeFiber.Object3DNode<THREE.Bone>
+      lineSegments: ReactThreeFiber.Object3DNode<THREE.LineSegments>
+      lineLoop: ReactThreeFiber.Object3DNode<THREE.LineLoop>
+      // @ts-ignore
+      line: ReactThreeFiber.Object3DNode<THREE.Line>
+      points: ReactThreeFiber.Object3DNode<THREE.Points>
+      group: ReactThreeFiber.Object3DNode<THREE.Group>
+      immediateRenderObject: ReactThreeFiber.Object3DNode<THREE.ImmediateRenderObject>
+
+      // cameras
+      camera: ReactThreeFiber.Object3DNode<THREE.Camera>
+      perspectiveCamera: ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera>
+      orthographicCamera: ReactThreeFiber.Object3DNode<THREE.OrthographicCamera>
+      cubeCamera: ReactThreeFiber.Object3DNode<THREE.CubeCamera>
+      arrayCamera: ReactThreeFiber.Object3DNode<THREE.ArrayCamera>
+
+      // geometry
+      geometry: ReactThreeFiber.GeometryNode<THREE.Geometry>
+      instancedBufferGeometry: ReactThreeFiber.GeometryNode<THREE.InstancedBufferGeometry>
+      bufferGeometry: ReactThreeFiber.GeometryNode<THREE.BufferGeometry>
+      wireframeGeometry: ReactThreeFiber.GeometryNode<THREE.WireframeGeometry>
+      parametricGeometry: ReactThreeFiber.GeometryNode<THREE.ParametricGeometry>
+      tetrahedronGeometry: ReactThreeFiber.GeometryNode<THREE.TetrahedronGeometry>
+      octahedronGeometry: ReactThreeFiber.GeometryNode<THREE.OctahedronGeometry>
+      icosahedronGeometry: ReactThreeFiber.GeometryNode<THREE.IcosahedronGeometry>
+      dodecahedronGeometry: ReactThreeFiber.GeometryNode<THREE.DodecahedronGeometry>
+      polyhedronGeometry: ReactThreeFiber.GeometryNode<THREE.PolyhedronGeometry>
+      tubeGeometry: ReactThreeFiber.GeometryNode<THREE.TubeGeometry>
+      torusKnotGeometry: ReactThreeFiber.GeometryNode<THREE.TorusKnotGeometry>
+      torusGeometry: ReactThreeFiber.GeometryNode<THREE.TorusGeometry>
+      textGeometry: ReactThreeFiber.GeometryNode<THREE.TextGeometry>
+      sphereGeometry: ReactThreeFiber.GeometryNode<THREE.SphereGeometry>
+      ringGeometry: ReactThreeFiber.GeometryNode<THREE.RingGeometry>
+      planeGeometry: ReactThreeFiber.GeometryNode<THREE.PlaneGeometry>
+      latheGeometry: ReactThreeFiber.GeometryNode<THREE.LatheGeometry>
+      shapeGeometry: ReactThreeFiber.GeometryNode<THREE.ShapeGeometry>
+      extrudeGeometry: ReactThreeFiber.GeometryNode<THREE.ExtrudeGeometry>
+      edgesGeometry: ReactThreeFiber.GeometryNode<THREE.EdgesGeometry>
+      coneGeometry: ReactThreeFiber.GeometryNode<THREE.ConeGeometry>
+      cylinderGeometry: ReactThreeFiber.GeometryNode<THREE.CylinderGeometry>
+      circleGeometry: ReactThreeFiber.GeometryNode<THREE.CircleGeometry>
+      boxGeometry: ReactThreeFiber.GeometryNode<THREE.BoxGeometry>
+
+      // materials
+      material: ReactThreeFiber.MaterialNode<THREE.Material, [THREE.MaterialParameters]>
+      shadowMaterial: ReactThreeFiber.MaterialNode<THREE.ShadowMaterial, [THREE.ShaderMaterialParameters]>
+      spriteMaterial: ReactThreeFiber.MaterialNode<THREE.SpriteMaterial, [THREE.SpriteMaterialParameters]>
+      rawShaderMaterial: ReactThreeFiber.MaterialNode<THREE.RawShaderMaterial, [THREE.ShaderMaterialParameters]>
+      shaderMaterial: ReactThreeFiber.MaterialNode<THREE.ShaderMaterial, [THREE.ShaderMaterialParameters]>
+      pointsMaterial: ReactThreeFiber.MaterialNode<THREE.PointsMaterial, [THREE.PointsMaterialParameters]>
+      meshPhysicalMaterial: ReactThreeFiber.MaterialNode<
+        THREE.MeshPhysicalMaterial,
+        [THREE.MeshPhysicalMaterialParameters]
+      >
+      meshStandardMaterial: ReactThreeFiber.MaterialNode<
+        THREE.MeshStandardMaterial,
+        [THREE.MeshStandardMaterialParameters]
+      >
+      meshPhongMaterial: ReactThreeFiber.MaterialNode<THREE.MeshPhongMaterial, [THREE.MeshPhongMaterialParameters]>
+      meshToonMaterial: ReactThreeFiber.MaterialNode<THREE.MeshToonMaterial, [THREE.MeshToonMaterialParameters]>
+      meshNormalMaterial: ReactThreeFiber.MaterialNode<THREE.MeshNormalMaterial, [THREE.MeshNormalMaterialParameters]>
+      meshLambertMaterial: ReactThreeFiber.MaterialNode<
+        THREE.MeshLambertMaterial,
+        [THREE.MeshLambertMaterialParameters]
+      >
+      meshDepthMaterial: ReactThreeFiber.MaterialNode<THREE.MeshDepthMaterial, [THREE.MeshDepthMaterialParameters]>
+      meshDistanceMaterial: ReactThreeFiber.MaterialNode<
+        THREE.MeshDistanceMaterial,
+        [THREE.MeshDistanceMaterialParameters]
+      >
+      meshBasicMaterial: ReactThreeFiber.MaterialNode<THREE.MeshBasicMaterial, [THREE.MeshBasicMaterialParameters]>
+      meshMatcapMaterial: ReactThreeFiber.MaterialNode<THREE.MeshMatcapMaterial, [THREE.MeshMatcapMaterialParameters]>
+      lineDashedMaterial: ReactThreeFiber.MaterialNode<THREE.LineDashedMaterial, [THREE.LineDashedMaterialParameters]>
+      lineBasicMaterial: ReactThreeFiber.MaterialNode<THREE.LineBasicMaterial, [THREE.LineBasicMaterialParameters]>
+
+      // lights and other
+      light: ReactThreeFiber.Object3DNode<THREE.Light>
+      spotLightShadow: ReactThreeFiber.Object3DNode<THREE.SpotLightShadow>
+      spotLight: ReactThreeFiber.Object3DNode<THREE.SpotLight>
+      pointLight: ReactThreeFiber.Object3DNode<THREE.PointLight>
+      rectAreaLight: ReactThreeFiber.Object3DNode<THREE.RectAreaLight>
+      hemisphereLight: ReactThreeFiber.Object3DNode<THREE.HemisphereLight>
+      directionalLightShadow: ReactThreeFiber.Object3DNode<THREE.DirectionalLightShadow>
+      directionalLight: ReactThreeFiber.Object3DNode<THREE.DirectionalLight>
+      ambientLight: ReactThreeFiber.Object3DNode<THREE.AmbientLight>
+      lightShadow: ReactThreeFiber.Object3DNode<THREE.LightShadow>
+      // @ts-ignore
+      ambientLightProbe: ReactThreeFiber.Object3DNode<THREE.AmbientLightProbe>
+      // @ts-ignore
+      hemisphereLightProbe: ReactThreeFiber.Object3DNode<THREE.HemisphereLightProbe>
+      // @ts-ignore
+      lightProbe: ReactThreeFiber.Object3DNode<THREE.LightProbe>
+
+      // helpers
+      vertexNormalsHelper: ReactThreeFiber.Object3DNode<THREE.VertexNormalsHelper>
+      spotLightHelper: ReactThreeFiber.Object3DNode<THREE.SpotLightHelper>
+      skeletonHelper: ReactThreeFiber.Object3DNode<THREE.SkeletonHelper>
+      pointLightHelper: ReactThreeFiber.Object3DNode<THREE.PointLightHelper>
+      rectAreaLightHelper: ReactThreeFiber.Object3DNode<THREE.RectAreaLightHelper>
+      hemisphereLightHelper: ReactThreeFiber.Object3DNode<THREE.HemisphereLightHelper>
+      gridHelper: ReactThreeFiber.Object3DNode<THREE.GridHelper>
+      polarGridHelper: ReactThreeFiber.Object3DNode<THREE.PolarGridHelper>
+      positionalAudioHelper: ReactThreeFiber.Object3DNode<THREE.PositionalAudioHelper>
+      faceNormalsHelper: ReactThreeFiber.Object3DNode<THREE.FaceNormalsHelper>
+      directionalLightHelper: ReactThreeFiber.Object3DNode<THREE.DirectionalLightHelper>
+      cameraHelper: ReactThreeFiber.Object3DNode<THREE.CameraHelper>
+      boxHelper: ReactThreeFiber.Object3DNode<THREE.BoxHelper>
+      box3Helper: ReactThreeFiber.Object3DNode<THREE.Box3Helper>
+      planeHelper: ReactThreeFiber.Object3DNode<THREE.PlaneHelper>
+      arrowHelper: ReactThreeFiber.Object3DNode<THREE.ArrowHelper>
+      axesHelper: ReactThreeFiber.Object3DNode<THREE.AxesHelper>
+
+      // textures
+      texture: ReactThreeFiber.Node<THREE.Texture>
+      videoTexture: ReactThreeFiber.Node<THREE.VideoTexture>
+      dataTexture: ReactThreeFiber.Node<THREE.DataTexture>
+      dataTexture3D: ReactThreeFiber.Node<THREE.DataTexture3D>
+      compressedTexture: ReactThreeFiber.Node<THREE.CompressedTexture>
+      cubeTexture: ReactThreeFiber.Node<THREE.CubeTexture>
+      canvasTexture: ReactThreeFiber.Node<THREE.CanvasTexture>
+      depthTexture: ReactThreeFiber.Node<THREE.DepthTexture>
+    }
+  }
+}

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -3,8 +3,11 @@ import { PointerEvent } from './canvas'
 
 export type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
 export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
-// @ts-ignore
-type Args<P> = P extends { prototype: any } ? Exclude<ConstructorParameters<P>, 'prototype'> : P
+
+/**
+ * If **T** contains a constructor, @see ConstructorParameters must be used, otherwise **T**.
+ */
+type Args<T> = T extends (new (...args: any) => any) ? ConstructorParameters<T> : T
 
 export namespace ReactThreeFiber {
   type Euler = THREE.Euler | number[]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
+export * from './src/three-types'
 export * from './src/canvas'
 import { useRender, useThree, useUpdate, useResource } from './src/hooks'
 import {

--- a/types/src/three-types.d.ts
+++ b/types/src/three-types.d.ts
@@ -5,11 +5,7 @@ export declare type NonFunctionKeys<T> = {
   [K in keyof T]: T[K] extends Function ? never : K
 }[keyof T]
 export declare type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
-declare type Args<P> = P extends {
-  prototype: any
-}
-  ? Exclude<ConstructorParameters<P>, 'prototype'>
-  : P
+declare type Args<T> = T extends (new (...args: any) => any) ? ConstructorParameters<T> : T
 export declare namespace ReactThreeFiber {
   type Euler = THREE.Euler | number[]
   type Matrix4 = THREE.Matrix4 | number[]

--- a/types/src/three-types.d.ts
+++ b/types/src/three-types.d.ts
@@ -5,11 +5,11 @@ export declare type NonFunctionKeys<T> = {
   [K in keyof T]: T[K] extends Function ? never : K
 }[keyof T]
 export declare type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
-export declare type ClassParams<T> = Parameters<Extract<T, (...args: any[]) => any>>
-export interface ClassSignature<T> {
-  new <K extends keyof T>(...args: ClassParams<T[K]>): T
+declare type Args<P> = P extends {
+  prototype: any
 }
-declare type Args<T> = ConstructorParameters<ClassSignature<T>>
+  ? Exclude<ConstructorParameters<P>, 'prototype'>
+  : P
 export declare namespace ReactThreeFiber {
   type Euler = THREE.Euler | number[]
   type Matrix4 = THREE.Matrix4 | number[]
@@ -24,38 +24,37 @@ export declare namespace ReactThreeFiber {
     onPointerMove?: (e: PointerEvent) => void
     onWheel?: (e: PointerEvent) => void
   }
-  type Node<T, P = Args<T>> = Overwrite<
+  type Node<T, P> = Overwrite<
     Partial<T>,
     {
       attach?: string
       attachArray?: string
       attachObject?: [string, string]
-      args?: P
+      args?: Args<P>
       children?: React.ReactNode
       ref?: React.Ref<React.ReactNode>
       key?: React.Key
       onUpdate?: (self: T) => void
     }
   >
-  type Object3DNode<T> = Overwrite<
-    Node<T>,
+  type Object3DNode<T, P> = Overwrite<
+    Node<T, P>,
     {
       position?: Vector3
       up?: Vector3
       scale?: Vector3
       rotation?: Euler
       matrix?: Matrix4
-      onUpdate?: (self: T) => void
     }
   > &
     ReactThreeFiber.Events
-  type GeometryNode<T> = Overwrite<
-    Node<T>,
+  type GeometryNode<T, P> = Overwrite<
+    Node<T, P>,
     {
       vertices?: Vector3[]
     }
   >
-  type MaterialNode<T, P = Args<T>> = Overwrite<
+  type MaterialNode<T, P> = Overwrite<
     Node<T, P>,
     {
       color?: Color
@@ -65,52 +64,58 @@ export declare namespace ReactThreeFiber {
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      audio: ReactThreeFiber.Object3DNode<THREE.Audio>
-      audioListener: ReactThreeFiber.Object3DNode<THREE.AudioListener>
-      positionalAudio: ReactThreeFiber.Object3DNode<THREE.PositionalAudio>
-      mesh: ReactThreeFiber.Object3DNode<THREE.Mesh>
-      scene: ReactThreeFiber.Object3DNode<THREE.Scene>
-      sprite: ReactThreeFiber.Object3DNode<THREE.Sprite>
-      lOD: ReactThreeFiber.Object3DNode<THREE.LOD>
-      skinnedMesh: ReactThreeFiber.Object3DNode<THREE.SkinnedMesh>
-      skeleton: ReactThreeFiber.Object3DNode<THREE.Skeleton>
-      bone: ReactThreeFiber.Object3DNode<THREE.Bone>
-      lineSegments: ReactThreeFiber.Object3DNode<THREE.LineSegments>
-      lineLoop: ReactThreeFiber.Object3DNode<THREE.LineLoop>
-      line: ReactThreeFiber.Object3DNode<THREE.Line>
-      points: ReactThreeFiber.Object3DNode<THREE.Points>
-      group: ReactThreeFiber.Object3DNode<THREE.Group>
-      immediateRenderObject: ReactThreeFiber.Object3DNode<THREE.ImmediateRenderObject>
-      camera: ReactThreeFiber.Object3DNode<THREE.Camera>
-      perspectiveCamera: ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera>
-      orthographicCamera: ReactThreeFiber.Object3DNode<THREE.OrthographicCamera>
-      cubeCamera: ReactThreeFiber.Object3DNode<THREE.CubeCamera>
-      arrayCamera: ReactThreeFiber.Object3DNode<THREE.ArrayCamera>
-      geometry: ReactThreeFiber.GeometryNode<THREE.Geometry>
-      instancedBufferGeometry: ReactThreeFiber.GeometryNode<THREE.InstancedBufferGeometry>
-      bufferGeometry: ReactThreeFiber.GeometryNode<THREE.BufferGeometry>
-      wireframeGeometry: ReactThreeFiber.GeometryNode<THREE.WireframeGeometry>
-      parametricGeometry: ReactThreeFiber.GeometryNode<THREE.ParametricGeometry>
-      tetrahedronGeometry: ReactThreeFiber.GeometryNode<THREE.TetrahedronGeometry>
-      octahedronGeometry: ReactThreeFiber.GeometryNode<THREE.OctahedronGeometry>
-      icosahedronGeometry: ReactThreeFiber.GeometryNode<THREE.IcosahedronGeometry>
-      dodecahedronGeometry: ReactThreeFiber.GeometryNode<THREE.DodecahedronGeometry>
-      polyhedronGeometry: ReactThreeFiber.GeometryNode<THREE.PolyhedronGeometry>
-      tubeGeometry: ReactThreeFiber.GeometryNode<THREE.TubeGeometry>
-      torusKnotGeometry: ReactThreeFiber.GeometryNode<THREE.TorusKnotGeometry>
-      torusGeometry: ReactThreeFiber.GeometryNode<THREE.TorusGeometry>
-      textGeometry: ReactThreeFiber.GeometryNode<THREE.TextGeometry>
-      sphereGeometry: ReactThreeFiber.GeometryNode<THREE.SphereGeometry>
-      ringGeometry: ReactThreeFiber.GeometryNode<THREE.RingGeometry>
-      planeGeometry: ReactThreeFiber.GeometryNode<THREE.PlaneGeometry>
-      latheGeometry: ReactThreeFiber.GeometryNode<THREE.LatheGeometry>
-      shapeGeometry: ReactThreeFiber.GeometryNode<THREE.ShapeGeometry>
-      extrudeGeometry: ReactThreeFiber.GeometryNode<THREE.ExtrudeGeometry>
-      edgesGeometry: ReactThreeFiber.GeometryNode<THREE.EdgesGeometry>
-      coneGeometry: ReactThreeFiber.GeometryNode<THREE.ConeGeometry>
-      cylinderGeometry: ReactThreeFiber.GeometryNode<THREE.CylinderGeometry>
-      circleGeometry: ReactThreeFiber.GeometryNode<THREE.CircleGeometry>
-      boxGeometry: ReactThreeFiber.GeometryNode<THREE.BoxGeometry>
+      audio: ReactThreeFiber.Object3DNode<THREE.Audio, typeof THREE.Audio>
+      audioListener: ReactThreeFiber.Object3DNode<THREE.AudioListener, typeof THREE.AudioListener>
+      positionalAudio: ReactThreeFiber.Object3DNode<THREE.PositionalAudio, typeof THREE.PositionalAudio>
+      mesh: ReactThreeFiber.Object3DNode<THREE.Mesh, typeof THREE.Mesh>
+      scene: ReactThreeFiber.Object3DNode<THREE.Scene, typeof THREE.Scene>
+      sprite: ReactThreeFiber.Object3DNode<THREE.Sprite, typeof THREE.Sprite>
+      lOD: ReactThreeFiber.Object3DNode<THREE.LOD, typeof THREE.LOD>
+      skinnedMesh: ReactThreeFiber.Object3DNode<THREE.SkinnedMesh, typeof THREE.SkinnedMesh>
+      skeleton: ReactThreeFiber.Object3DNode<THREE.Skeleton, typeof THREE.Skeleton>
+      bone: ReactThreeFiber.Object3DNode<THREE.Bone, typeof THREE.Bone>
+      lineSegments: ReactThreeFiber.Object3DNode<THREE.LineSegments, typeof THREE.LineSegments>
+      lineLoop: ReactThreeFiber.Object3DNode<THREE.LineLoop, typeof THREE.LineLoop>
+      line: ReactThreeFiber.Object3DNode<THREE.Line, typeof THREE.Line>
+      points: ReactThreeFiber.Object3DNode<THREE.Points, typeof THREE.Points>
+      group: ReactThreeFiber.Object3DNode<THREE.Group, typeof THREE.Group>
+      immediateRenderObject: ReactThreeFiber.Object3DNode<
+        THREE.ImmediateRenderObject,
+        typeof THREE.ImmediateRenderObject
+      >
+      camera: ReactThreeFiber.Object3DNode<THREE.Camera, typeof THREE.Camera>
+      perspectiveCamera: ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera, typeof THREE.PerspectiveCamera>
+      orthographicCamera: ReactThreeFiber.Object3DNode<THREE.OrthographicCamera, typeof THREE.OrthographicCamera>
+      cubeCamera: ReactThreeFiber.Object3DNode<THREE.CubeCamera, typeof THREE.CubeCamera>
+      arrayCamera: ReactThreeFiber.Object3DNode<THREE.ArrayCamera, typeof THREE.ArrayCamera>
+      geometry: ReactThreeFiber.GeometryNode<THREE.Geometry, typeof THREE.Geometry>
+      instancedBufferGeometry: ReactThreeFiber.GeometryNode<
+        THREE.InstancedBufferGeometry,
+        typeof THREE.InstancedBufferGeometry
+      >
+      bufferGeometry: ReactThreeFiber.GeometryNode<THREE.BufferGeometry, typeof THREE.BufferGeometry>
+      wireframeGeometry: ReactThreeFiber.GeometryNode<THREE.WireframeGeometry, typeof THREE.WireframeGeometry>
+      parametricGeometry: ReactThreeFiber.GeometryNode<THREE.ParametricGeometry, typeof THREE.ParametricGeometry>
+      tetrahedronGeometry: ReactThreeFiber.GeometryNode<THREE.TetrahedronGeometry, typeof THREE.TetrahedronGeometry>
+      octahedronGeometry: ReactThreeFiber.GeometryNode<THREE.OctahedronGeometry, typeof THREE.OctahedronGeometry>
+      icosahedronGeometry: ReactThreeFiber.GeometryNode<THREE.IcosahedronGeometry, typeof THREE.IcosahedronGeometry>
+      dodecahedronGeometry: ReactThreeFiber.GeometryNode<THREE.DodecahedronGeometry, typeof THREE.DodecahedronGeometry>
+      polyhedronGeometry: ReactThreeFiber.GeometryNode<THREE.PolyhedronGeometry, typeof THREE.PolyhedronGeometry>
+      tubeGeometry: ReactThreeFiber.GeometryNode<THREE.TubeGeometry, typeof THREE.TubeGeometry>
+      torusKnotGeometry: ReactThreeFiber.GeometryNode<THREE.TorusKnotGeometry, typeof THREE.TorusKnotGeometry>
+      torusGeometry: ReactThreeFiber.GeometryNode<THREE.TorusGeometry, typeof THREE.TorusGeometry>
+      textGeometry: ReactThreeFiber.GeometryNode<THREE.TextGeometry, typeof THREE.TextGeometry>
+      sphereGeometry: ReactThreeFiber.GeometryNode<THREE.SphereGeometry, typeof THREE.SphereGeometry>
+      ringGeometry: ReactThreeFiber.GeometryNode<THREE.RingGeometry, typeof THREE.RingGeometry>
+      planeGeometry: ReactThreeFiber.GeometryNode<THREE.PlaneGeometry, typeof THREE.PlaneGeometry>
+      latheGeometry: ReactThreeFiber.GeometryNode<THREE.LatheGeometry, typeof THREE.LatheGeometry>
+      shapeGeometry: ReactThreeFiber.GeometryNode<THREE.ShapeGeometry, typeof THREE.ShapeGeometry>
+      extrudeGeometry: ReactThreeFiber.GeometryNode<THREE.ExtrudeGeometry, typeof THREE.ExtrudeGeometry>
+      edgesGeometry: ReactThreeFiber.GeometryNode<THREE.EdgesGeometry, typeof THREE.EdgesGeometry>
+      coneGeometry: ReactThreeFiber.GeometryNode<THREE.ConeGeometry, typeof THREE.ConeGeometry>
+      cylinderGeometry: ReactThreeFiber.GeometryNode<THREE.CylinderGeometry, typeof THREE.CylinderGeometry>
+      circleGeometry: ReactThreeFiber.GeometryNode<THREE.CircleGeometry, typeof THREE.CircleGeometry>
+      boxGeometry: ReactThreeFiber.GeometryNode<THREE.BoxGeometry, typeof THREE.BoxGeometry>
       material: ReactThreeFiber.MaterialNode<THREE.Material, [THREE.MaterialParameters]>
       shadowMaterial: ReactThreeFiber.MaterialNode<THREE.ShadowMaterial, [THREE.ShaderMaterialParameters]>
       spriteMaterial: ReactThreeFiber.MaterialNode<THREE.SpriteMaterial, [THREE.SpriteMaterialParameters]>
@@ -141,44 +146,56 @@ declare global {
       meshMatcapMaterial: ReactThreeFiber.MaterialNode<THREE.MeshMatcapMaterial, [THREE.MeshMatcapMaterialParameters]>
       lineDashedMaterial: ReactThreeFiber.MaterialNode<THREE.LineDashedMaterial, [THREE.LineDashedMaterialParameters]>
       lineBasicMaterial: ReactThreeFiber.MaterialNode<THREE.LineBasicMaterial, [THREE.LineBasicMaterialParameters]>
-      light: ReactThreeFiber.Object3DNode<THREE.Light>
-      spotLightShadow: ReactThreeFiber.Object3DNode<THREE.SpotLightShadow>
-      spotLight: ReactThreeFiber.Object3DNode<THREE.SpotLight>
-      pointLight: ReactThreeFiber.Object3DNode<THREE.PointLight>
-      rectAreaLight: ReactThreeFiber.Object3DNode<THREE.RectAreaLight>
-      hemisphereLight: ReactThreeFiber.Object3DNode<THREE.HemisphereLight>
-      directionalLightShadow: ReactThreeFiber.Object3DNode<THREE.DirectionalLightShadow>
-      directionalLight: ReactThreeFiber.Object3DNode<THREE.DirectionalLight>
-      ambientLight: ReactThreeFiber.Object3DNode<THREE.AmbientLight>
-      lightShadow: ReactThreeFiber.Object3DNode<THREE.LightShadow>
-      ambientLightProbe: ReactThreeFiber.Object3DNode<THREE.AmbientLightProbe>
-      hemisphereLightProbe: ReactThreeFiber.Object3DNode<THREE.HemisphereLightProbe>
-      lightProbe: ReactThreeFiber.Object3DNode<THREE.LightProbe>
-      vertexNormalsHelper: ReactThreeFiber.Object3DNode<THREE.VertexNormalsHelper>
-      spotLightHelper: ReactThreeFiber.Object3DNode<THREE.SpotLightHelper>
-      skeletonHelper: ReactThreeFiber.Object3DNode<THREE.SkeletonHelper>
-      pointLightHelper: ReactThreeFiber.Object3DNode<THREE.PointLightHelper>
-      rectAreaLightHelper: ReactThreeFiber.Object3DNode<THREE.RectAreaLightHelper>
-      hemisphereLightHelper: ReactThreeFiber.Object3DNode<THREE.HemisphereLightHelper>
-      gridHelper: ReactThreeFiber.Object3DNode<THREE.GridHelper>
-      polarGridHelper: ReactThreeFiber.Object3DNode<THREE.PolarGridHelper>
-      positionalAudioHelper: ReactThreeFiber.Object3DNode<THREE.PositionalAudioHelper>
-      faceNormalsHelper: ReactThreeFiber.Object3DNode<THREE.FaceNormalsHelper>
-      directionalLightHelper: ReactThreeFiber.Object3DNode<THREE.DirectionalLightHelper>
-      cameraHelper: ReactThreeFiber.Object3DNode<THREE.CameraHelper>
-      boxHelper: ReactThreeFiber.Object3DNode<THREE.BoxHelper>
-      box3Helper: ReactThreeFiber.Object3DNode<THREE.Box3Helper>
-      planeHelper: ReactThreeFiber.Object3DNode<THREE.PlaneHelper>
-      arrowHelper: ReactThreeFiber.Object3DNode<THREE.ArrowHelper>
-      axesHelper: ReactThreeFiber.Object3DNode<THREE.AxesHelper>
-      texture: ReactThreeFiber.Node<THREE.Texture>
-      videoTexture: ReactThreeFiber.Node<THREE.VideoTexture>
-      dataTexture: ReactThreeFiber.Node<THREE.DataTexture>
-      dataTexture3D: ReactThreeFiber.Node<THREE.DataTexture3D>
-      compressedTexture: ReactThreeFiber.Node<THREE.CompressedTexture>
-      cubeTexture: ReactThreeFiber.Node<THREE.CubeTexture>
-      canvasTexture: ReactThreeFiber.Node<THREE.CanvasTexture>
-      depthTexture: ReactThreeFiber.Node<THREE.DepthTexture>
+      light: ReactThreeFiber.Object3DNode<THREE.Light, typeof THREE.Light>
+      spotLightShadow: ReactThreeFiber.Object3DNode<THREE.SpotLightShadow, typeof THREE.SpotLightShadow>
+      spotLight: ReactThreeFiber.Object3DNode<THREE.SpotLight, typeof THREE.SpotLight>
+      pointLight: ReactThreeFiber.Object3DNode<THREE.PointLight, typeof THREE.PointLight>
+      rectAreaLight: ReactThreeFiber.Object3DNode<THREE.RectAreaLight, typeof THREE.RectAreaLight>
+      hemisphereLight: ReactThreeFiber.Object3DNode<THREE.HemisphereLight, typeof THREE.HemisphereLight>
+      directionalLightShadow: ReactThreeFiber.Object3DNode<
+        THREE.DirectionalLightShadow,
+        typeof THREE.DirectionalLightShadow
+      >
+      directionalLight: ReactThreeFiber.Object3DNode<THREE.DirectionalLight, typeof THREE.DirectionalLight>
+      ambientLight: ReactThreeFiber.Object3DNode<THREE.AmbientLight, typeof THREE.AmbientLight>
+      lightShadow: ReactThreeFiber.Object3DNode<THREE.LightShadow, typeof THREE.LightShadow>
+      ambientLightProbe: ReactThreeFiber.Object3DNode<THREE.AmbientLightProbe, typeof THREE.AmbientLightProbe>
+      hemisphereLightProbe: ReactThreeFiber.Object3DNode<THREE.HemisphereLightProbe, typeof THREE.HemisphereLightProbe>
+      lightProbe: ReactThreeFiber.Object3DNode<THREE.LightProbe, typeof THREE.LightProbe>
+      vertexNormalsHelper: ReactThreeFiber.Object3DNode<THREE.VertexNormalsHelper, typeof THREE.VertexNormalsHelper>
+      spotLightHelper: ReactThreeFiber.Object3DNode<THREE.SpotLightHelper, typeof THREE.SpotLightHelper>
+      skeletonHelper: ReactThreeFiber.Object3DNode<THREE.SkeletonHelper, typeof THREE.SkeletonHelper>
+      pointLightHelper: ReactThreeFiber.Object3DNode<THREE.PointLightHelper, typeof THREE.PointLightHelper>
+      rectAreaLightHelper: ReactThreeFiber.Object3DNode<THREE.RectAreaLightHelper, typeof THREE.RectAreaLightHelper>
+      hemisphereLightHelper: ReactThreeFiber.Object3DNode<
+        THREE.HemisphereLightHelper,
+        typeof THREE.HemisphereLightHelper
+      >
+      gridHelper: ReactThreeFiber.Object3DNode<THREE.GridHelper, typeof THREE.GridHelper>
+      polarGridHelper: ReactThreeFiber.Object3DNode<THREE.PolarGridHelper, typeof THREE.PolarGridHelper>
+      positionalAudioHelper: ReactThreeFiber.Object3DNode<
+        THREE.PositionalAudioHelper,
+        typeof THREE.PositionalAudioHelper
+      >
+      faceNormalsHelper: ReactThreeFiber.Object3DNode<THREE.FaceNormalsHelper, typeof THREE.FaceNormalsHelper>
+      directionalLightHelper: ReactThreeFiber.Object3DNode<
+        THREE.DirectionalLightHelper,
+        typeof THREE.DirectionalLightHelper
+      >
+      cameraHelper: ReactThreeFiber.Object3DNode<THREE.CameraHelper, typeof THREE.CameraHelper>
+      boxHelper: ReactThreeFiber.Object3DNode<THREE.BoxHelper, typeof THREE.BoxHelper>
+      box3Helper: ReactThreeFiber.Object3DNode<THREE.Box3Helper, typeof THREE.Box3Helper>
+      planeHelper: ReactThreeFiber.Object3DNode<THREE.PlaneHelper, typeof THREE.PlaneHelper>
+      arrowHelper: ReactThreeFiber.Object3DNode<THREE.ArrowHelper, typeof THREE.ArrowHelper>
+      axesHelper: ReactThreeFiber.Object3DNode<THREE.AxesHelper, typeof THREE.AxesHelper>
+      texture: ReactThreeFiber.Node<THREE.Texture, typeof THREE.Texture>
+      videoTexture: ReactThreeFiber.Node<THREE.VideoTexture, typeof THREE.VideoTexture>
+      dataTexture: ReactThreeFiber.Node<THREE.DataTexture, typeof THREE.DataTexture>
+      dataTexture3D: ReactThreeFiber.Node<THREE.DataTexture3D, typeof THREE.DataTexture3D>
+      compressedTexture: ReactThreeFiber.Node<THREE.CompressedTexture, typeof THREE.CompressedTexture>
+      cubeTexture: ReactThreeFiber.Node<THREE.CubeTexture, typeof THREE.CubeTexture>
+      canvasTexture: ReactThreeFiber.Node<THREE.CanvasTexture, typeof THREE.CanvasTexture>
+      depthTexture: ReactThreeFiber.Node<THREE.DepthTexture, typeof THREE.DepthTexture>
     }
   }
 }

--- a/types/src/three-types.d.ts
+++ b/types/src/three-types.d.ts
@@ -1,15 +1,16 @@
+/// <reference types="react" />
 import * as THREE from 'three'
-import { PointerEvent } from './src/canvas'
-
-export type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
-export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
-export type ClassParams<T> = Parameters<Extract<T, (...args: any[]) => any>>
+import { PointerEvent } from './canvas'
+export declare type NonFunctionKeys<T> = {
+  [K in keyof T]: T[K] extends Function ? never : K
+}[keyof T]
+export declare type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
+export declare type ClassParams<T> = Parameters<Extract<T, (...args: any[]) => any>>
 export interface ClassSignature<T> {
   new <K extends keyof T>(...args: ClassParams<T[K]>): T
 }
-type Args<T> = ConstructorParameters<ClassSignature<T>>
-
-export namespace ReactThreeFiber {
+declare type Args<T> = ConstructorParameters<ClassSignature<T>>
+export declare namespace ReactThreeFiber {
   type Euler = THREE.Euler | number[]
   type Matrix4 = THREE.Matrix4 | number[]
   type Vector3 = THREE.Vector3 | number[]
@@ -23,17 +24,12 @@ export namespace ReactThreeFiber {
     onPointerMove?: (e: PointerEvent) => void
     onWheel?: (e: PointerEvent) => void
   }
-
   type Node<T, P = Args<T>> = Overwrite<
     Partial<T>,
     {
-      /** Attaches this class onto the parent under the given name and nulls it on unmount */
       attach?: string
-      /** Appends this class to an array on the parent under the given name and removes it on unmount */
       attachArray?: string
-      /** Adds this class to an object on the parent under the given name and deletes it on unmount */
       attachObject?: [string, string]
-      /** Constructor arguments */
       args?: P
       children?: React.ReactNode
       ref?: React.Ref<React.ReactNode>
@@ -41,7 +37,6 @@ export namespace ReactThreeFiber {
       onUpdate?: (self: T) => void
     }
   >
-
   type Object3DNode<T> = Overwrite<
     Node<T>,
     {
@@ -54,14 +49,12 @@ export namespace ReactThreeFiber {
     }
   > &
     ReactThreeFiber.Events
-
   type GeometryNode<T> = Overwrite<
     Node<T>,
     {
       vertices?: Vector3[]
     }
   >
-
   type MaterialNode<T, P = Args<T>> = Overwrite<
     Node<T, P>,
     {
@@ -69,14 +62,12 @@ export namespace ReactThreeFiber {
     }
   >
 }
-
 declare global {
   namespace JSX {
     interface IntrinsicElements {
       audio: ReactThreeFiber.Object3DNode<THREE.Audio>
       audioListener: ReactThreeFiber.Object3DNode<THREE.AudioListener>
       positionalAudio: ReactThreeFiber.Object3DNode<THREE.PositionalAudio>
-
       mesh: ReactThreeFiber.Object3DNode<THREE.Mesh>
       scene: ReactThreeFiber.Object3DNode<THREE.Scene>
       sprite: ReactThreeFiber.Object3DNode<THREE.Sprite>
@@ -90,15 +81,11 @@ declare global {
       points: ReactThreeFiber.Object3DNode<THREE.Points>
       group: ReactThreeFiber.Object3DNode<THREE.Group>
       immediateRenderObject: ReactThreeFiber.Object3DNode<THREE.ImmediateRenderObject>
-
-      // cameras
       camera: ReactThreeFiber.Object3DNode<THREE.Camera>
       perspectiveCamera: ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera>
       orthographicCamera: ReactThreeFiber.Object3DNode<THREE.OrthographicCamera>
       cubeCamera: ReactThreeFiber.Object3DNode<THREE.CubeCamera>
       arrayCamera: ReactThreeFiber.Object3DNode<THREE.ArrayCamera>
-
-      // geometry
       geometry: ReactThreeFiber.GeometryNode<THREE.Geometry>
       instancedBufferGeometry: ReactThreeFiber.GeometryNode<THREE.InstancedBufferGeometry>
       bufferGeometry: ReactThreeFiber.GeometryNode<THREE.BufferGeometry>
@@ -124,8 +111,6 @@ declare global {
       cylinderGeometry: ReactThreeFiber.GeometryNode<THREE.CylinderGeometry>
       circleGeometry: ReactThreeFiber.GeometryNode<THREE.CircleGeometry>
       boxGeometry: ReactThreeFiber.GeometryNode<THREE.BoxGeometry>
-
-      // materials
       material: ReactThreeFiber.MaterialNode<THREE.Material, [THREE.MaterialParameters]>
       shadowMaterial: ReactThreeFiber.MaterialNode<THREE.ShadowMaterial, [THREE.ShaderMaterialParameters]>
       spriteMaterial: ReactThreeFiber.MaterialNode<THREE.SpriteMaterial, [THREE.SpriteMaterialParameters]>
@@ -156,8 +141,6 @@ declare global {
       meshMatcapMaterial: ReactThreeFiber.MaterialNode<THREE.MeshMatcapMaterial, [THREE.MeshMatcapMaterialParameters]>
       lineDashedMaterial: ReactThreeFiber.MaterialNode<THREE.LineDashedMaterial, [THREE.LineDashedMaterialParameters]>
       lineBasicMaterial: ReactThreeFiber.MaterialNode<THREE.LineBasicMaterial, [THREE.LineBasicMaterialParameters]>
-
-      // lights and other
       light: ReactThreeFiber.Object3DNode<THREE.Light>
       spotLightShadow: ReactThreeFiber.Object3DNode<THREE.SpotLightShadow>
       spotLight: ReactThreeFiber.Object3DNode<THREE.SpotLight>
@@ -171,8 +154,6 @@ declare global {
       ambientLightProbe: ReactThreeFiber.Object3DNode<THREE.AmbientLightProbe>
       hemisphereLightProbe: ReactThreeFiber.Object3DNode<THREE.HemisphereLightProbe>
       lightProbe: ReactThreeFiber.Object3DNode<THREE.LightProbe>
-
-      // helpers
       vertexNormalsHelper: ReactThreeFiber.Object3DNode<THREE.VertexNormalsHelper>
       spotLightHelper: ReactThreeFiber.Object3DNode<THREE.SpotLightHelper>
       skeletonHelper: ReactThreeFiber.Object3DNode<THREE.SkeletonHelper>
@@ -190,8 +171,6 @@ declare global {
       planeHelper: ReactThreeFiber.Object3DNode<THREE.PlaneHelper>
       arrowHelper: ReactThreeFiber.Object3DNode<THREE.ArrowHelper>
       axesHelper: ReactThreeFiber.Object3DNode<THREE.AxesHelper>
-
-      // textures
       texture: ReactThreeFiber.Node<THREE.Texture>
       videoTexture: ReactThreeFiber.Node<THREE.VideoTexture>
       dataTexture: ReactThreeFiber.Node<THREE.DataTexture>
@@ -203,3 +182,4 @@ declare global {
     }
   }
 }
+export {}


### PR DESCRIPTION
We have problems with the types of `args` property. These did not match the THREE class types and caused type script errors.