### PR TITLE
Add "primitive" type

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-size-snapshot": "^0.8.0",
-    "three": "^0.104.0",
+    "three": "^0.107.0",
     "typescript": "^3.5.3",
     "wait-on": "^3.2.0"
   }

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -159,6 +159,9 @@ declare global {
       lineDashedMaterial: ReactThreeFiber.MaterialNode<THREE.LineDashedMaterial, [THREE.LineDashedMaterialParameters]>
       lineBasicMaterial: ReactThreeFiber.MaterialNode<THREE.LineBasicMaterial, [THREE.LineBasicMaterialParameters]>
 
+      // primitive
+      primitive: { object: any } & { [properties: string]: any }
+
       // lights and other
       light: ReactThreeFiber.Object3DNode<THREE.Light, typeof THREE.Light>
       spotLightShadow: ReactThreeFiber.Node<THREE.SpotLightShadow, typeof THREE.SpotLightShadow>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5042,10 +5042,10 @@ three@*:
   version "0.103.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.103.0.tgz#63b3dbccc861caad93269618061a73dadebae71b"
 
-three@^0.104.0:
-  version "0.104.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.104.0.tgz#9ad1da492153b753a89e0df066631215bd9d9087"
-  integrity sha512-q617IMBC5k40U2E9UC4/LtmhzTOOLB1jGMIooUL+QrhZ7abiGCSDrKrpCDt9V8RTl6xw+0FYfA1PYsIPKbQOgg==
+three@^0.107.0:
+  version "0.107.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.107.0.tgz#0c862c348d61bd3f22058e01f5e771c1294315a1"
+  integrity sha512-vqbKJRLBEviPVa7poEzXocobicwxzsctr5mnymA7n8fEzcVS49rYP0RrwqZ98JqujRoruK+/YzcchNpRP+kXsQ==
 
 throttleit@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Adds a `primitive` type. I'm not sure if we can add better typing for this but this should resolve https://github.com/drcmda/react-three-fiber/issues/160.

Also updated `three` dev dep to match peer dep (let me know if that should be separate PR).